### PR TITLE
Implement pet CRUD handlers and controller

### DIFF
--- a/Rs.Api/Controllers/PetController.cs
+++ b/Rs.Api/Controllers/PetController.cs
@@ -1,0 +1,54 @@
+using Rs.Application.Features.Pets.CommandHandlers.AddPet;
+using Rs.Application.Features.Pets.CommandHandlers.UpdatePet;
+using Rs.Application.Features.Pets.CommandHandlers.DeletePet;
+using Rs.Application.Features.Pets.QueryHandlers.GetPet;
+using Rs.Application.Features.Pets.QueryHandlers.GetPets;
+
+namespace Rs.Api.Controllers;
+
+[Authorize]
+public class PetController : BaseController
+{
+    [HttpGet]
+    public async Task<ActionResult<List<GetPetsResponse>>> GetPets(CancellationToken cancellationToken)
+    {
+        var query = new GetPetsQuery();
+        var response = await Mediator.Send(query, cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<GetPetResponse>> GetPet(Guid id, CancellationToken cancellationToken)
+    {
+        var query = new GetPetQuery(id);
+        var response = await Mediator.Send(query, cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<AddPetResponse>> AddPet([FromBody] AddPetCommand command, CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(command, cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<UpdatePetResponse>> UpdatePet(Guid id, [FromBody] UpdatePetCommand command, CancellationToken cancellationToken)
+    {
+        if (id != command.Id)
+        {
+            return BadRequest();
+        }
+
+        var response = await Mediator.Send(command, cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<ActionResult<DeletePetResponse>> DeletePet(Guid id, CancellationToken cancellationToken)
+    {
+        var command = new DeletePetCommand(id);
+        var response = await Mediator.Send(command, cancellationToken);
+        return response.ToActionResult();
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetCommand.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetCommand.cs
@@ -1,0 +1,16 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.AddPet;
+
+public sealed record AddPetCommand(
+    string Name,
+    string PhotoUrl,
+    DateTime? BirthDate,
+    string Species,
+    string Breed,
+    string Gender,
+    double? WeightKg,
+    string HealthStatus,
+    string VaccinationStatus,
+    string Country,
+    string City,
+    Guid OwnerId
+) : ICommand<AddPetResponse>;

--- a/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetCommandHandler.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetCommandHandler.cs
@@ -1,0 +1,32 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.CommandHandlers.AddPet;
+
+public class AddPetCommandHandler(IDataContext context, IMapper mapper, ILogger<AddPetCommandHandler> logger)
+    : ICommandHandler<AddPetCommand, AddPetResponse>
+{
+    public async Task<Result<AddPetResponse>> Handle(AddPetCommand request, CancellationToken cancellationToken)
+    {
+        var pet = new Pet(Guid.NewGuid(),
+            request.Name,
+            request.PhotoUrl,
+            request.BirthDate,
+            request.Species,
+            request.Breed,
+            request.Gender,
+            request.WeightKg,
+            request.HealthStatus,
+            request.VaccinationStatus,
+            request.Country,
+            request.City,
+            request.OwnerId,
+            null!,
+            false);
+
+        await context.Pets.AddAsync(pet, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var response = mapper.Map<AddPetResponse>(pet);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetCommandValidator.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetCommandValidator.cs
@@ -1,0 +1,18 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.AddPet;
+
+public class AddPetCommandValidator : AbstractValidator<AddPetCommand>
+{
+    public AddPetCommandValidator()
+    {
+        RuleFor(c => c.Name)
+            .NotEmpty().WithMessage("Name is required.")
+            .MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
+
+        RuleFor(c => c.Species)
+            .NotEmpty().WithMessage("Species is required.")
+            .MaximumLength(50).WithMessage("Species must not exceed 50 characters.");
+
+        RuleFor(c => c.OwnerId)
+            .NotEmpty().WithMessage("OwnerId is required.");
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetResponse.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/AddPet/AddPetResponse.cs
@@ -1,0 +1,24 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.CommandHandlers.AddPet;
+
+[AutoMap(typeof(Pet))]
+public sealed class AddPetResponse
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string PhotoUrl { get; set; }
+    public DateTime? BirthDate { get; set; }
+    public string Species { get; set; }
+    public string Breed { get; set; }
+    public string Gender { get; set; }
+    public double? WeightKg { get; set; }
+    public string HealthStatus { get; set; }
+    public string VaccinationStatus { get; set; }
+    public string Country { get; set; }
+    public string City { get; set; }
+    public Guid OwnerId { get; set; }
+    public bool IsArchived { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetCommand.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetCommand.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.DeletePet;
+
+public sealed record DeletePetCommand(Guid Id) : ICommand<DeletePetResponse>;

--- a/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetCommandHandler.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetCommandHandler.cs
@@ -1,0 +1,19 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.DeletePet;
+
+public class DeletePetCommandHandler(IDataContext context, ILogger<DeletePetCommandHandler> logger)
+    : ICommandHandler<DeletePetCommand, DeletePetResponse>
+{
+    public async Task<Result<DeletePetResponse>> Handle(DeletePetCommand request, CancellationToken cancellationToken)
+    {
+        var pet = await context.Pets.FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
+        if (pet == null)
+        {
+            return Result.Failure<DeletePetResponse>(PetErrors.NotFound);
+        }
+
+        context.Pets.Remove(pet);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return new DeletePetResponse(true);
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetCommandValidator.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetCommandValidator.cs
@@ -1,0 +1,10 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.DeletePet;
+
+public class DeletePetCommandValidator : AbstractValidator<DeletePetCommand>
+{
+    public DeletePetCommandValidator()
+    {
+        RuleFor(c => c.Id)
+            .NotEmpty().WithMessage("Id is required.");
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetResponse.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/DeletePet/DeletePetResponse.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.DeletePet;
+
+public sealed record DeletePetResponse(bool IsDeleted);

--- a/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommand.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommand.cs
@@ -1,0 +1,17 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.UpdatePet;
+
+public sealed record UpdatePetCommand(
+    Guid Id,
+    string Name,
+    string PhotoUrl,
+    DateTime? BirthDate,
+    string Species,
+    string Breed,
+    string Gender,
+    double? WeightKg,
+    string HealthStatus,
+    string VaccinationStatus,
+    string Country,
+    string City,
+    Guid OwnerId
+) : ICommand<UpdatePetResponse>;

--- a/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommandHandler.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommandHandler.cs
@@ -1,0 +1,35 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.CommandHandlers.UpdatePet;
+
+public class UpdatePetCommandHandler(IDataContext context, IMapper mapper, ILogger<UpdatePetCommandHandler> logger)
+    : ICommandHandler<UpdatePetCommand, UpdatePetResponse>
+{
+    public async Task<Result<UpdatePetResponse>> Handle(UpdatePetCommand request, CancellationToken cancellationToken)
+    {
+        var pet = await context.Pets.FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
+        if (pet == null)
+        {
+            return Result.Failure<UpdatePetResponse>(PetErrors.NotFound);
+        }
+
+        pet.Name = request.Name;
+        pet.PhotoUrl = request.PhotoUrl;
+        pet.BirthDate = request.BirthDate;
+        pet.Species = request.Species;
+        pet.Breed = request.Breed;
+        pet.Gender = request.Gender;
+        pet.WeightKg = request.WeightKg;
+        pet.HealthStatus = request.HealthStatus;
+        pet.VaccinationStatus = request.VaccinationStatus;
+        pet.Country = request.Country;
+        pet.City = request.City;
+        pet.OwnerId = request.OwnerId;
+        pet.UpdatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var response = mapper.Map<UpdatePetResponse>(pet);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommandValidator.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommandValidator.cs
@@ -1,0 +1,21 @@
+namespace Rs.Application.Features.Pets.CommandHandlers.UpdatePet;
+
+public class UpdatePetCommandValidator : AbstractValidator<UpdatePetCommand>
+{
+    public UpdatePetCommandValidator()
+    {
+        RuleFor(c => c.Id)
+            .NotEmpty().WithMessage("Id is required.");
+
+        RuleFor(c => c.Name)
+            .NotEmpty().WithMessage("Name is required.")
+            .MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
+
+        RuleFor(c => c.Species)
+            .NotEmpty().WithMessage("Species is required.")
+            .MaximumLength(50).WithMessage("Species must not exceed 50 characters.");
+
+        RuleFor(c => c.OwnerId)
+            .NotEmpty().WithMessage("OwnerId is required.");
+    }
+}

--- a/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetResponse.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetResponse.cs
@@ -1,0 +1,24 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.CommandHandlers.UpdatePet;
+
+[AutoMap(typeof(Pet))]
+public sealed class UpdatePetResponse
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string PhotoUrl { get; set; }
+    public DateTime? BirthDate { get; set; }
+    public string Species { get; set; }
+    public string Breed { get; set; }
+    public string Gender { get; set; }
+    public double? WeightKg { get; set; }
+    public string HealthStatus { get; set; }
+    public string VaccinationStatus { get; set; }
+    public string Country { get; set; }
+    public string City { get; set; }
+    public Guid OwnerId { get; set; }
+    public bool IsArchived { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Rs.Application/Features/Pets/PetErrors.cs
+++ b/Rs.Application/Features/Pets/PetErrors.cs
@@ -1,0 +1,9 @@
+namespace Rs.Application.Features.Pets;
+
+public static class PetErrors
+{
+    public static readonly Error NotFound = new(
+        HttpErrorCode.NotFound,
+        "Pet.NotFound",
+        "Pet not found.");
+}

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetQuery.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetQuery.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPet;
+
+public sealed record GetPetQuery(Guid Id) : IQuery<GetPetResponse>;

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetQueryHandler.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetQueryHandler.cs
@@ -1,0 +1,19 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPet;
+
+public class GetPetQueryHandler(IDataContext context, IMapper mapper)
+    : IQueryHandler<GetPetQuery, GetPetResponse>
+{
+    public async Task<Result<GetPetResponse>> Handle(GetPetQuery request, CancellationToken cancellationToken)
+    {
+        var pet = await context.Pets.AsNoTracking().FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
+        if (pet == null)
+        {
+            return Result.Failure<GetPetResponse>(PetErrors.NotFound);
+        }
+
+        var response = mapper.Map<GetPetResponse>(pet);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetQueryValidator.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetQueryValidator.cs
@@ -1,0 +1,10 @@
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPet;
+
+public class GetPetQueryValidator : AbstractValidator<GetPetQuery>
+{
+    public GetPetQueryValidator()
+    {
+        RuleFor(q => q.Id)
+            .NotEmpty().WithMessage("Id is required.");
+    }
+}

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetResponse.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPet/GetPetResponse.cs
@@ -1,0 +1,24 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPet;
+
+[AutoMap(typeof(Pet))]
+public sealed class GetPetResponse
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string PhotoUrl { get; set; }
+    public DateTime? BirthDate { get; set; }
+    public string Species { get; set; }
+    public string Breed { get; set; }
+    public string Gender { get; set; }
+    public double? WeightKg { get; set; }
+    public string HealthStatus { get; set; }
+    public string VaccinationStatus { get; set; }
+    public string Country { get; set; }
+    public string City { get; set; }
+    public Guid OwnerId { get; set; }
+    public bool IsArchived { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPets/GetPetsQuery.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPets/GetPetsQuery.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPets;
+
+public sealed record GetPetsQuery() : IQuery<List<GetPetsResponse>>;

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPets/GetPetsQueryHandler.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPets/GetPetsQueryHandler.cs
@@ -1,0 +1,16 @@
+using AutoMapper.QueryableExtensions;
+
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPets;
+
+public class GetPetsQueryHandler(IDataContext context, IMapper mapper)
+    : IQueryHandler<GetPetsQuery, List<GetPetsResponse>>
+{
+    public async Task<Result<List<GetPetsResponse>>> Handle(GetPetsQuery request, CancellationToken cancellationToken)
+    {
+        var pets = await context.Pets.AsNoTracking()
+            .ProjectTo<GetPetsResponse>(mapper.ConfigurationProvider)
+            .ToListAsync(cancellationToken);
+
+        return pets;
+    }
+}

--- a/Rs.Application/Features/Pets/QueryHandlers/GetPets/GetPetsResponse.cs
+++ b/Rs.Application/Features/Pets/QueryHandlers/GetPets/GetPetsResponse.cs
@@ -1,0 +1,24 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Application.Features.Pets.QueryHandlers.GetPets;
+
+[AutoMap(typeof(Pet))]
+public sealed class GetPetsResponse
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string PhotoUrl { get; set; }
+    public DateTime? BirthDate { get; set; }
+    public string Species { get; set; }
+    public string Breed { get; set; }
+    public string Gender { get; set; }
+    public double? WeightKg { get; set; }
+    public string HealthStatus { get; set; }
+    public string VaccinationStatus { get; set; }
+    public string Country { get; set; }
+    public string City { get; set; }
+    public Guid OwnerId { get; set; }
+    public bool IsArchived { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Rs.Domain/Common/Interfaces/IDataContext.cs
+++ b/Rs.Domain/Common/Interfaces/IDataContext.cs
@@ -4,6 +4,7 @@ using Rs.Domain.Aggregates.Files;
 using Rs.Domain.Aggregates.Provinces;
 using Rs.Domain.Aggregates.RealEstates;
 using Rs.Domain.Aggregates.Requests;
+using Rs.Domain.Aggregates.Pets;
 
 namespace Rs.Domain.Common.Interfaces;
 
@@ -25,8 +26,10 @@ public interface IDataContext
     DbSet<Request> Requests { get; }
 
     DbSet<FileManager> FileManagers { get; }
-    
+
     DbSet<RealEstate> RealEstates { get; }
+
+    DbSet<Pet> Pets { get; }
     int SaveChanges();
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);

--- a/Rs.Persistence/DbPersistence/DataContext.cs
+++ b/Rs.Persistence/DbPersistence/DataContext.cs
@@ -5,6 +5,7 @@ using Rs.Domain.Aggregates.Files;
 using Rs.Domain.Aggregates.Provinces;
 using Rs.Domain.Aggregates.RealEstates;
 using Rs.Domain.Aggregates.Requests;
+using Rs.Domain.Aggregates.Pets;
 using Rs.Domain.Common.Interfaces;
 
 namespace Rs.Persistence.DbPersistence;
@@ -27,8 +28,10 @@ public class DataContext(DbContextOptions<DataContext> options)
     public DbSet<Request> Requests { get; init; }
     
     public DbSet<FileManager> FileManagers { get; init; }
-    
+
     public DbSet<RealEstate> RealEstates { get; init; }
+
+    public DbSet<Pet> Pets { get; init; }
 
     public override int SaveChanges()
     {


### PR DESCRIPTION
## Summary
- add CRUD command and query handlers for pets with FluentValidation
- register `Pet` entity in data context
- rewrite `PetController` to use mediator pattern like other controllers

## Testing
- `dotnet build Rs.Api.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab005e108332ad6542df200ba7c2