### PR TITLE
Add EF Core configuration for pet entities

### DIFF
--- a/Rs.Persistence/Common/SchemaConfig.cs
+++ b/Rs.Persistence/Common/SchemaConfig.cs
@@ -8,4 +8,5 @@ public class SchemaConfig
     public const string Request = "Request";
     public const string File = "File";
     public const string RealEstate = "RealEstate";
+    public const string Pet = "Pet";
 }

--- a/Rs.Persistence/Configurations/Pets/ActivityRecordConfiguration.cs
+++ b/Rs.Persistence/Configurations/Pets/ActivityRecordConfiguration.cs
@@ -1,0 +1,17 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Persistence.Configurations.Pets;
+
+public class ActivityRecordConfiguration : IEntityTypeConfiguration<ActivityRecord>
+{
+    public void Configure(EntityTypeBuilder<ActivityRecord> builder)
+    {
+        builder.HasKey(ar => ar.Id);
+
+        builder.HasOne(ar => ar.Pet)
+            .WithMany(p => p.Activities)
+            .HasForeignKey(ar => ar.PetId);
+
+        builder.ToTable("ActivityRecords", SchemaConfig.Pet);
+    }
+}

--- a/Rs.Persistence/Configurations/Pets/MedicalRecordConfiguration.cs
+++ b/Rs.Persistence/Configurations/Pets/MedicalRecordConfiguration.cs
@@ -1,0 +1,17 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Persistence.Configurations.Pets;
+
+public class MedicalRecordConfiguration : IEntityTypeConfiguration<MedicalRecord>
+{
+    public void Configure(EntityTypeBuilder<MedicalRecord> builder)
+    {
+        builder.HasKey(mr => mr.Id);
+
+        builder.HasOne(mr => mr.Pet)
+            .WithMany(p => p.MedicalHistory)
+            .HasForeignKey(mr => mr.PetId);
+
+        builder.ToTable("MedicalRecords", SchemaConfig.Pet);
+    }
+}

--- a/Rs.Persistence/Configurations/Pets/PetConfiguration.cs
+++ b/Rs.Persistence/Configurations/Pets/PetConfiguration.cs
@@ -1,0 +1,17 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Persistence.Configurations.Pets;
+
+public class PetConfiguration : IEntityTypeConfiguration<Pet>
+{
+    public void Configure(EntityTypeBuilder<Pet> builder)
+    {
+        builder.HasKey(p => p.Id);
+
+        builder.HasOne(p => p.Owner)
+            .WithMany()
+            .HasForeignKey(p => p.OwnerId);
+
+        builder.ToTable("Pets", SchemaConfig.Pet);
+    }
+}

--- a/Rs.Persistence/Configurations/Pets/VaccinationRecordConfiguration.cs
+++ b/Rs.Persistence/Configurations/Pets/VaccinationRecordConfiguration.cs
@@ -1,0 +1,17 @@
+using Rs.Domain.Aggregates.Pets;
+
+namespace Rs.Persistence.Configurations.Pets;
+
+public class VaccinationRecordConfiguration : IEntityTypeConfiguration<VaccinationRecord>
+{
+    public void Configure(EntityTypeBuilder<VaccinationRecord> builder)
+    {
+        builder.HasKey(vr => vr.Id);
+
+        builder.HasOne(vr => vr.Pet)
+            .WithMany(p => p.Vaccinations)
+            .HasForeignKey(vr => vr.PetId);
+
+        builder.ToTable("VaccinationRecords", SchemaConfig.Pet);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Pet` schema constant
- map `Pet`, `ActivityRecord`, `MedicalRecord` and `VaccinationRecord` entities with relationships

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b30271e883328ac735c1798f9125