### PR TITLE
Refactor file service to handle missing WebRootPath

### DIFF
--- a/Rs.Infrastructure/Services/FileService.cs
+++ b/Rs.Infrastructure/Services/FileService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Rs.Application.Common.Models;
 using Rs.Domain.Shared;
@@ -9,27 +9,29 @@ namespace Rs.Infrastructure.Services;
 
 public class FileService(IWebHostEnvironment hostEnvironment) : IFileService
 {
+    private readonly string rootPath = hostEnvironment.WebRootPath
+                                      ?? hostEnvironment.ContentRootPath
+                                      ?? Directory.GetCurrentDirectory();
+
     public async Task<Result<FileUploadResult>> UploadFileAsync(IFormFile file, string writeTo)
     {
         try
         {
             var fileName = FileUtility.SafeFileName(file);
-            var directoryPath = Path.Combine(hostEnvironment.WebRootPath, writeTo);
+            var directoryPath = Path.Combine(rootPath, writeTo);
+            Directory.CreateDirectory(directoryPath);
+
             var path = Path.Combine(directoryPath, fileName);
 
-            if (!string.IsNullOrEmpty(directoryPath))
-            {
-                Directory.CreateDirectory(directoryPath);
-            }
-            
             await using var fs = new FileStream(path, FileMode.Create);
             await file.CopyToAsync(fs);
 
-            return FileUploadResult.Add(fileName,
+            return FileUploadResult.Add(
+                fileName,
                 Path.GetExtension(file.FileName),
                 Path.Combine(writeTo, fileName));
         }
-        catch (Exception e)
+        catch
         {
             return Result.Failure<FileUploadResult>(FileUploadError.CanNotUploadFile);
         }
@@ -37,31 +39,39 @@ public class FileService(IWebHostEnvironment hostEnvironment) : IFileService
 
     public Result<FileStream> GetFile(string filePath)
     {
-        var path = Path.Combine(hostEnvironment.WebRootPath, filePath);
-
-        if (!File.Exists(path))
+        try
         {
-            return Result.Failure<FileStream>(FileUploadError.NotExistFile);
+            var path = Path.Combine(rootPath, filePath);
+
+            if (!File.Exists(path))
+            {
+                return Result.Failure<FileStream>(FileUploadError.NotExistFile);
+            }
+
+            var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            return fileStream;
         }
-        var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
-        return fileStream;
+        catch
+        {
+            return Result.Failure<FileStream>(FileUploadError.CanNotUploadFile);
+        }
     }
 
     public Result<bool> DeleteFile(string filePath)
     {
-        var path = Path.Combine(hostEnvironment.WebRootPath, filePath);
-        
-        if (!File.Exists(path))
-        {
-            return Result.Failure<bool>(FileUploadError.NotExistFile);
-        }
         try
         {
-            File.Delete(path);
+            var path = Path.Combine(rootPath, filePath);
 
+            if (!File.Exists(path))
+            {
+                return Result.Failure<bool>(FileUploadError.NotExistFile);
+            }
+
+            File.Delete(path);
             return true;
         }
-        catch (Exception e)
+        catch
         {
             return Result.Failure<bool>(FileUploadError.CanNotUploadFile);
         }


### PR DESCRIPTION
## Summary
- refactor FileService to resolve uploads against a fallback root path when `WebRootPath` is unavailable
- streamline file operations with centralized path handling and additional error checks

## Testing
- ⚠️ `dotnet build Rs.Api.sln` *(dotnet not installed in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68b1c47f812083329da1916728f32386