### PR TITLE
Support photo upload in pet update handler

### DIFF
--- a/Rs.Api/Controllers/PetController.cs
+++ b/Rs.Api/Controllers/PetController.cs
@@ -35,7 +35,7 @@ public class PetController : BaseController
     }
 
     [HttpPut("{id:guid}")]
-    public async Task<ActionResult<UpdatePetResponse>> UpdatePet(Guid id, [FromBody] UpdatePetCommand command, CancellationToken cancellationToken)
+    public async Task<ActionResult<UpdatePetResponse>> UpdatePet(Guid id, [FromForm] UpdatePetCommand command, CancellationToken cancellationToken)
     {
         if (id != command.Id)
         {

--- a/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommand.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommand.cs
@@ -1,9 +1,11 @@
 namespace Rs.Application.Features.Pets.CommandHandlers.UpdatePet;
 
+using Microsoft.AspNetCore.Http;
+
 public sealed record UpdatePetCommand(
     Guid Id,
     string Name,
-    string PhotoUrl,
+    IFormFile? Photo,
     DateTime? BirthDate,
     string Species,
     string Breed,
@@ -12,6 +14,5 @@ public sealed record UpdatePetCommand(
     string HealthStatus,
     string VaccinationStatus,
     string Country,
-    string City,
-    Guid OwnerId
+    string City
 ) : ICommand<UpdatePetResponse>;

--- a/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommandValidator.cs
+++ b/Rs.Application/Features/Pets/CommandHandlers/UpdatePet/UpdatePetCommandValidator.cs
@@ -14,8 +14,5 @@ public class UpdatePetCommandValidator : AbstractValidator<UpdatePetCommand>
         RuleFor(c => c.Species)
             .NotEmpty().WithMessage("Species is required.")
             .MaximumLength(50).WithMessage("Species must not exceed 50 characters.");
-
-        RuleFor(c => c.OwnerId)
-            .NotEmpty().WithMessage("OwnerId is required.");
     }
 }


### PR DESCRIPTION
## Summary
- Allow updating pet photos with optional file upload
- Simplify update command and validator to match add semantics
- Accept form data when updating pets

## Testing
- `dotnet build Rs.Api.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c95292f48332ad54b4ac3a32f2e8