### PR TITLE
Add order APIs for checkout and retrieval

### DIFF
--- a/Rs.Api/Controllers/CartController.cs
+++ b/Rs.Api/Controllers/CartController.cs
@@ -1,0 +1,31 @@
+using Rs.Application.Features.Carts.CommandHandlers.AddCartItem;
+using Rs.Application.Features.Carts.CommandHandlers.RemoveCartItem;
+using Rs.Application.Features.Carts.QueryHandlers.GetCart;
+
+namespace Rs.Api.Controllers;
+
+[Authorize]
+public class CartController : BaseController
+{
+    [HttpGet]
+    public async Task<ActionResult<GetCartResponse>> GetCart(CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(new GetCartQuery(), cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpPost("items")]
+    public async Task<ActionResult<AddCartItemResponse>> AddItem([FromBody] AddCartItemCommand command, CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(command, cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpDelete("items/{id:guid}")]
+    public async Task<ActionResult> RemoveItem(Guid id, CancellationToken cancellationToken)
+    {
+        var command = new RemoveCartItemCommand(id);
+        var response = await Mediator.Send(command, cancellationToken);
+        return response.ToActionResult();
+    }
+}

--- a/Rs.Api/Controllers/OrderController.cs
+++ b/Rs.Api/Controllers/OrderController.cs
@@ -1,0 +1,22 @@
+using Rs.Application.Features.Orders.CommandHandlers.PlaceOrder;
+using Rs.Application.Features.Orders.QueryHandlers.GetOrders;
+
+namespace Rs.Api.Controllers;
+
+[Authorize]
+public class OrderController : BaseController
+{
+    [HttpGet]
+    public async Task<ActionResult<List<GetOrdersResponse>>> GetOrders(CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(new GetOrdersQuery(), cancellationToken);
+        return response.ToActionResult();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<PlaceOrderResponse>> PlaceOrder([FromBody] PlaceOrderCommand command, CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(command, cancellationToken);
+        return response.ToActionResult();
+    }
+}

--- a/Rs.Application/Features/Carts/CartErrors.cs
+++ b/Rs.Application/Features/Carts/CartErrors.cs
@@ -1,0 +1,19 @@
+namespace Rs.Application.Features.Carts;
+
+public static class CartErrors
+{
+    public static readonly Error NotFound = new(
+        HttpErrorCode.NotFound,
+        "Cart.NotFound",
+        "Cart not found.");
+
+    public static readonly Error ProductNotFound = new(
+        HttpErrorCode.NotFound,
+        "Product.NotFound",
+        "Product not found.");
+
+    public static readonly Error ItemNotFound = new(
+        HttpErrorCode.NotFound,
+        "CartItem.NotFound",
+        "Cart item not found.");
+}

--- a/Rs.Application/Features/Carts/CartMappingProfile.cs
+++ b/Rs.Application/Features/Carts/CartMappingProfile.cs
@@ -1,0 +1,10 @@
+namespace Rs.Application.Features.Carts;
+
+public class CartMappingProfile : Profile
+{
+    public CartMappingProfile()
+    {
+        CreateMap<CartItem, QueryHandlers.GetCart.GetCartItemResponse>();
+        CreateMap<Cart, QueryHandlers.GetCart.GetCartResponse>();
+    }
+}

--- a/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemCommand.cs
+++ b/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemCommand.cs
@@ -1,0 +1,6 @@
+namespace Rs.Application.Features.Carts.CommandHandlers.AddCartItem;
+
+public sealed record AddCartItemCommand(
+    Guid ProductId,
+    int Quantity
+) : ICommand<AddCartItemResponse>;

--- a/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemCommandHandler.cs
+++ b/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemCommandHandler.cs
@@ -1,0 +1,54 @@
+namespace Rs.Application.Features.Carts.CommandHandlers.AddCartItem;
+
+public class AddCartItemCommandHandler(
+    IDataContext context,
+    IUser user)
+    : ICommandHandler<AddCartItemCommand, AddCartItemResponse>
+{
+    public async Task<Result<AddCartItemResponse>> Handle(AddCartItemCommand request, CancellationToken cancellationToken)
+    {
+        var cart = await context.Carts
+            .Include(c => c.Items)
+            .FirstOrDefaultAsync(c => c.UserId == user.Id && c.Status == CartStatus.Active, cancellationToken);
+
+        if (cart is null)
+        {
+            cart = new Cart
+            {
+                Id = Guid.NewGuid(),
+                UserId = user.Id!.Value,
+                Status = CartStatus.Active,
+            };
+            await context.Carts.AddAsync(cart, cancellationToken);
+        }
+
+        var product = await context.Products.FindAsync(new object?[] { request.ProductId }, cancellationToken);
+        if (product is null)
+        {
+            return Result.Failure<AddCartItemResponse>(CartErrors.ProductNotFound);
+        }
+
+        var item = cart.Items.FirstOrDefault(i => i.ProductId == request.ProductId);
+        if (item is null)
+        {
+            item = new CartItem
+            {
+                Id = Guid.NewGuid(),
+                ProductId = request.ProductId,
+                Quantity = request.Quantity,
+                UnitPrice = product.DiscountPrice ?? product.Price,
+                AddedAtUtc = DateTimeOffset.UtcNow
+            };
+            cart.Items.Add(item);
+        }
+        else
+        {
+            item.Quantity += request.Quantity;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var response = new AddCartItemResponse(cart.Id, item.Id);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemCommandValidator.cs
+++ b/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemCommandValidator.cs
@@ -1,0 +1,10 @@
+namespace Rs.Application.Features.Carts.CommandHandlers.AddCartItem;
+
+public class AddCartItemCommandValidator : AbstractValidator<AddCartItemCommand>
+{
+    public AddCartItemCommandValidator()
+    {
+        RuleFor(x => x.ProductId).NotEmpty();
+        RuleFor(x => x.Quantity).GreaterThan(0);
+    }
+}

--- a/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemResponse.cs
+++ b/Rs.Application/Features/Carts/CommandHandlers/AddCartItem/AddCartItemResponse.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Carts.CommandHandlers.AddCartItem;
+
+public sealed record AddCartItemResponse(Guid CartId, Guid CartItemId);

--- a/Rs.Application/Features/Carts/CommandHandlers/RemoveCartItem/RemoveCartItemCommand.cs
+++ b/Rs.Application/Features/Carts/CommandHandlers/RemoveCartItem/RemoveCartItemCommand.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Carts.CommandHandlers.RemoveCartItem;
+
+public sealed record RemoveCartItemCommand(Guid CartItemId) : ICommand;

--- a/Rs.Application/Features/Carts/CommandHandlers/RemoveCartItem/RemoveCartItemCommandHandler.cs
+++ b/Rs.Application/Features/Carts/CommandHandlers/RemoveCartItem/RemoveCartItemCommandHandler.cs
@@ -1,0 +1,24 @@
+namespace Rs.Application.Features.Carts.CommandHandlers.RemoveCartItem;
+
+public class RemoveCartItemCommandHandler(
+    IDataContext context,
+    IUser user)
+    : ICommandHandler<RemoveCartItemCommand>
+{
+    public async Task<Result> Handle(RemoveCartItemCommand request, CancellationToken cancellationToken)
+    {
+        var cartItem = await context.CartItems
+            .Include(ci => ci.Cart)
+            .FirstOrDefaultAsync(ci => ci.Id == request.CartItemId && ci.Cart.UserId == user.Id, cancellationToken);
+
+        if (cartItem is null)
+        {
+            return Result.Failure(CartErrors.ItemNotFound);
+        }
+
+        context.CartItems.Remove(cartItem);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Rs.Application/Features/Carts/QueryHandlers/GetCart/GetCartQuery.cs
+++ b/Rs.Application/Features/Carts/QueryHandlers/GetCart/GetCartQuery.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Carts.QueryHandlers.GetCart;
+
+public sealed record GetCartQuery : IQuery<GetCartResponse>;

--- a/Rs.Application/Features/Carts/QueryHandlers/GetCart/GetCartQueryHandler.cs
+++ b/Rs.Application/Features/Carts/QueryHandlers/GetCart/GetCartQueryHandler.cs
@@ -1,0 +1,23 @@
+namespace Rs.Application.Features.Carts.QueryHandlers.GetCart;
+
+public class GetCartQueryHandler(
+    IDataContext context,
+    IMapper mapper,
+    IUser user)
+    : IQueryHandler<GetCartQuery, GetCartResponse>
+{
+    public async Task<Result<GetCartResponse>> Handle(GetCartQuery request, CancellationToken cancellationToken)
+    {
+        var cart = await context.Carts.AsNoTracking()
+            .Include(c => c.Items)
+            .FirstOrDefaultAsync(c => c.UserId == user.Id && c.Status == CartStatus.Active, cancellationToken);
+
+        if (cart is null)
+        {
+            return Result.Failure<GetCartResponse>(CartErrors.NotFound);
+        }
+
+        var response = mapper.Map<GetCartResponse>(cart);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Carts/QueryHandlers/GetCart/GetCartResponse.cs
+++ b/Rs.Application/Features/Carts/QueryHandlers/GetCart/GetCartResponse.cs
@@ -1,0 +1,12 @@
+namespace Rs.Application.Features.Carts.QueryHandlers.GetCart;
+
+public sealed record GetCartResponse(
+    Guid Id,
+    CartStatus Status,
+    List<GetCartItemResponse> Items);
+
+public sealed record GetCartItemResponse(
+    Guid Id,
+    Guid ProductId,
+    int Quantity,
+    decimal UnitPrice);

--- a/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderCommand.cs
+++ b/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderCommand.cs
@@ -1,0 +1,16 @@
+namespace Rs.Application.Features.Orders.CommandHandlers.PlaceOrder;
+
+public sealed record PlaceOrderAddress(
+    string FirstName,
+    string LastName,
+    string Phone,
+    string Country,
+    string City,
+    string Line1,
+    string? Line2,
+    string PostalCode);
+
+public sealed record PlaceOrderCommand(
+    PlaceOrderAddress ShippingAddress,
+    PlaceOrderAddress BillingAddress
+) : ICommand<PlaceOrderResponse>;

--- a/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderCommandHandler.cs
+++ b/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderCommandHandler.cs
@@ -1,0 +1,73 @@
+using Rs.Application.Features.Carts;
+using Rs.Domain.Aggregates.PetShop.ValueObjects;
+
+namespace Rs.Application.Features.Orders.CommandHandlers.PlaceOrder;
+
+public class PlaceOrderCommandHandler(
+    IDataContext context,
+    IUser user)
+    : ICommandHandler<PlaceOrderCommand, PlaceOrderResponse>
+{
+    public async Task<Result<PlaceOrderResponse>> Handle(PlaceOrderCommand request, CancellationToken cancellationToken)
+    {
+        var cart = await context.Carts
+            .Include(c => c.Items)
+            .FirstOrDefaultAsync(c => c.UserId == user.Id && c.Status == CartStatus.Active, cancellationToken);
+
+        if (cart is null)
+        {
+            return Result.Failure<PlaceOrderResponse>(CartErrors.NotFound);
+        }
+
+        if (cart.Items.Count == 0)
+        {
+            return Result.Failure<PlaceOrderResponse>(OrderErrors.CartEmpty);
+        }
+
+        var order = new Order
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id!.Value,
+            OrderNumber = $"ORD-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}",
+            OrderDateUtc = DateTimeOffset.UtcNow,
+            Status = OrderStatus.Pending,
+            TotalAmount = cart.Items.Sum(i => i.UnitPrice * i.Quantity),
+            DiscountAmount = 0,
+            ShippingAddress = new Address(
+                request.ShippingAddress.FirstName,
+                request.ShippingAddress.LastName,
+                request.ShippingAddress.Phone,
+                request.ShippingAddress.Country,
+                request.ShippingAddress.City,
+                request.ShippingAddress.Line1,
+                request.ShippingAddress.Line2,
+                request.ShippingAddress.PostalCode),
+            BillingAddress = new Address(
+                request.BillingAddress.FirstName,
+                request.BillingAddress.LastName,
+                request.BillingAddress.Phone,
+                request.BillingAddress.Country,
+                request.BillingAddress.City,
+                request.BillingAddress.Line1,
+                request.BillingAddress.Line2,
+                request.BillingAddress.PostalCode),
+            Items = cart.Items.Select(ci => new OrderItem
+            {
+                Id = Guid.NewGuid(),
+                ProductId = ci.ProductId,
+                Quantity = ci.Quantity,
+                UnitPrice = ci.UnitPrice
+            }).ToList()
+        };
+
+        await context.Orders.AddAsync(order, cancellationToken);
+
+        cart.Status = CartStatus.CheckedOut;
+        cart.Items.Clear();
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var response = new PlaceOrderResponse(order.Id, order.OrderNumber);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderCommandValidator.cs
+++ b/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderCommandValidator.cs
@@ -1,0 +1,21 @@
+namespace Rs.Application.Features.Orders.CommandHandlers.PlaceOrder;
+
+public class PlaceOrderCommandValidator : AbstractValidator<PlaceOrderCommand>
+{
+    public PlaceOrderCommandValidator()
+    {
+        RuleFor(x => x.ShippingAddress).NotNull();
+        RuleFor(x => x.BillingAddress).NotNull();
+
+        RuleForEach(x => new[] { x.ShippingAddress, x.BillingAddress }).ChildRules(address =>
+        {
+            address.RuleFor(a => a.FirstName).NotEmpty();
+            address.RuleFor(a => a.LastName).NotEmpty();
+            address.RuleFor(a => a.Phone).NotEmpty();
+            address.RuleFor(a => a.Country).NotEmpty();
+            address.RuleFor(a => a.City).NotEmpty();
+            address.RuleFor(a => a.Line1).NotEmpty();
+            address.RuleFor(a => a.PostalCode).NotEmpty();
+        });
+    }
+}

--- a/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderResponse.cs
+++ b/Rs.Application/Features/Orders/CommandHandlers/PlaceOrder/PlaceOrderResponse.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Orders.CommandHandlers.PlaceOrder;
+
+public sealed record PlaceOrderResponse(Guid OrderId, string OrderNumber);

--- a/Rs.Application/Features/Orders/OrderErrors.cs
+++ b/Rs.Application/Features/Orders/OrderErrors.cs
@@ -1,0 +1,14 @@
+namespace Rs.Application.Features.Orders;
+
+public static class OrderErrors
+{
+    public static readonly Error CartEmpty = new(
+        HttpErrorCode.BadRequest,
+        "Cart.Empty",
+        "Cart is empty.");
+
+    public static readonly Error NotFound = new(
+        HttpErrorCode.NotFound,
+        "Order.NotFound",
+        "Order not found.");
+}

--- a/Rs.Application/Features/Orders/OrderMappingProfile.cs
+++ b/Rs.Application/Features/Orders/OrderMappingProfile.cs
@@ -1,0 +1,13 @@
+using Rs.Domain.Aggregates.PetShop.ValueObjects;
+
+namespace Rs.Application.Features.Orders;
+
+public class OrderMappingProfile : Profile
+{
+    public OrderMappingProfile()
+    {
+        CreateMap<OrderItem, QueryHandlers.GetOrders.GetOrderItemResponse>();
+        CreateMap<Address, QueryHandlers.GetOrders.OrderAddressResponse>();
+        CreateMap<Order, QueryHandlers.GetOrders.GetOrdersResponse>();
+    }
+}

--- a/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrderItemResponse.cs
+++ b/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrderItemResponse.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Orders.QueryHandlers.GetOrders;
+
+public sealed record GetOrderItemResponse(Guid ProductId, int Quantity, decimal UnitPrice);

--- a/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrdersQuery.cs
+++ b/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrdersQuery.cs
@@ -1,0 +1,3 @@
+namespace Rs.Application.Features.Orders.QueryHandlers.GetOrders;
+
+public sealed record GetOrdersQuery() : IQuery<List<GetOrdersResponse>>;

--- a/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrdersQueryHandler.cs
+++ b/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrdersQueryHandler.cs
@@ -1,0 +1,20 @@
+namespace Rs.Application.Features.Orders.QueryHandlers.GetOrders;
+
+public class GetOrdersQueryHandler(
+    IDataContext context,
+    IMapper mapper,
+    IUser user)
+    : IQueryHandler<GetOrdersQuery, List<GetOrdersResponse>>
+{
+    public async Task<Result<List<GetOrdersResponse>>> Handle(GetOrdersQuery request, CancellationToken cancellationToken)
+    {
+        var orders = await context.Orders.AsNoTracking()
+            .Include(o => o.Items)
+            .Where(o => o.UserId == user.Id)
+            .OrderByDescending(o => o.OrderDateUtc)
+            .ToListAsync(cancellationToken);
+
+        var response = mapper.Map<List<GetOrdersResponse>>(orders);
+        return response;
+    }
+}

--- a/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrdersResponse.cs
+++ b/Rs.Application/Features/Orders/QueryHandlers/GetOrders/GetOrdersResponse.cs
@@ -1,0 +1,12 @@
+namespace Rs.Application.Features.Orders.QueryHandlers.GetOrders;
+
+public sealed record GetOrdersResponse(
+    Guid Id,
+    string OrderNumber,
+    DateTimeOffset OrderDateUtc,
+    OrderStatus Status,
+    decimal TotalAmount,
+    decimal DiscountAmount,
+    OrderAddressResponse ShippingAddress,
+    OrderAddressResponse BillingAddress,
+    List<GetOrderItemResponse> Items);

--- a/Rs.Application/Features/Orders/QueryHandlers/GetOrders/OrderAddressResponse.cs
+++ b/Rs.Application/Features/Orders/QueryHandlers/GetOrders/OrderAddressResponse.cs
@@ -1,0 +1,11 @@
+namespace Rs.Application.Features.Orders.QueryHandlers.GetOrders;
+
+public sealed record OrderAddressResponse(
+    string FirstName,
+    string LastName,
+    string Phone,
+    string Country,
+    string City,
+    string Line1,
+    string? Line2,
+    string PostalCode);


### PR DESCRIPTION
## Summary
- add order placement and retrieval features, including command/handlers and mapping
- expose order endpoints for placing an order and listing orders

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b29fb3f0cc83328111121b46155008